### PR TITLE
lf line endings for *.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,6 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+# Vagrant
+*.sh	text eol=lf


### PR DESCRIPTION
fix crlf error:
/tmp/vagrant-shell: /usr/local/bin/lukida_sync: /bin/bash^M: bad interpreter: No such file or directory
