### PR TITLE
Vagrant: web access via 192.168.33.12, not lukida.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ SetEnv MODE "development"
 ```
 Remember the URL to access lukida (e.g. http://lukida.domain.tld)
 
-*** Important ***
+**Important**
 There is a .htaccess file located in this folder, which is neccessary.
 
 6) Enter the URL in the mail config file ../lukida/libraries/lukida_newlibrary/general.ini:
@@ -67,15 +67,14 @@ Try the URL in your browser.
 ###Vagrant virtual machine
 For a local developer system, you can use a virtual machine with Virtualbox and Vagrant. These are the installation steps:
 
-1) Be sure to have [Virtualbox](https://www.virtualbox.org/wiki/Downloads) installed.
-2) You need a POSIX compatible shell - on MS Windows [GIT Bash](https://git-for-windows.github.io/) is verified to work.
-3) Install [Vagrant](https://www.vagrantup.com/downloads.html) (if not present) with Virtualbox guest additions plugin (execute ```vagrant plugin install vagrant-vbguest``` in a shell after the installation of Vagrant).
-4) Navigate to the projects root folder in your shell (e.g. the folder with the [Vagrantfile](Vagrantfile)).
-5) Run `vagrant up` to automatically download, start and initially provision the virtual machine.
-6) Add the ip 192.168.33.12 as "lukida.dev" to your hosts file (/etc/hosts on POSIX compatible systems, C:\Windows\System32\drivers\etc\hosts on Windows systems).
+1. Be sure to have [Virtualbox](https://www.virtualbox.org/wiki/Downloads) installed.
+2. You need a POSIX compatible shell - on MS Windows [GIT Bash](https://git-for-windows.github.io/) is verified to work.
+3. Install [Vagrant](https://www.vagrantup.com/downloads.html) (if not present) with Virtualbox guest additions plugin (execute ```vagrant plugin install vagrant-vbguest``` in a shell after the installation of Vagrant).
+4. Navigate to the projects root folder in your shell (e.g. the folder with the [Vagrantfile](Vagrantfile)).
+5. Run `vagrant up` to automatically download, start and initially provision the virtual machine.
 
 Usage hints:
-- Lukida can be accessed via http://lukida.dev; the db admin via http://lukida.dev/phpmyadmin (user: newlibrary, password: newlibrary)
+- Lukida can be accessed via http://192.168.33.12; the db admin via http://192.168.33.12/phpmyadmin/ (user: newlibrary, password: newlibrary)
 - you can develop on your host system without immediate impact
 - a connection into the virtual machine running Lukida can be done with ```vagrant ssh```
 - to apply changes made in the code, run ```lukida_sync``` from inside the virtual machine

--- a/libraries/Lukida_newlibrary/general.ini
+++ b/libraries/Lukida_newlibrary/general.ini
@@ -13,7 +13,7 @@ frontpage=false
 imprint=http://somewhere
 mailfrom=
 ; Multiple Develpment URLs (separated by , without protocol)
-devurl=newlibrary.local
+devurl=192.168.33.12,newlibrary.local
 ; One Production URL (with protocol)
 produrl=http://example.local
 

--- a/vagrant/vm_provision.sh
+++ b/vagrant/vm_provision.sh
@@ -25,6 +25,7 @@ mysql -unewlibrary -pnewlibrary newlibrary < /vagrant/mysql_import.sql
 
 echo "### START CONFIGURING THE PROJECT ###"
 sudo cp /vagrant/vagrant/lukida_apache.conf /etc/apache2/sites-available/lukida.conf
+sudo a2dissite 000-default.conf
 sudo a2ensite lukida
 sudo a2enmod rewrite
 sudo cp /vagrant/vagrant/sync_project.sh /usr/local/bin/lukida_sync


### PR DESCRIPTION
This avoids to change /etc/hosts
